### PR TITLE
Fixed issue with HybridAuth templates

### DIFF
--- a/core/components/office/controllers/profile.class.php
+++ b/core/components/office/controllers/profile.class.php
@@ -95,7 +95,7 @@ class officeProfileController extends officeDefaultController {
 			if ($this->modx->loadClass('hybridauth', MODX_CORE_PATH . 'components/hybridauth/model/hybridauth/', false, true)) {
 				$HybridAuth = new HybridAuth($this->modx, $this->config);
 				$HybridAuth->initialize($this->modx->context->key);
-				$pls['providers'] = $HybridAuth->getProvidersLinks();
+				$pls['providers'] = $HybridAuth->getProvidersLinks($this->config['providerTpl'], $this->config['activeProviderTpl']);
 			}
 		}
 


### PR DESCRIPTION
В HybridAuth не передавались шаблоны из конфига, из-за этого всегда используются шаблоны по умолчанию.